### PR TITLE
Implementing configuration statement HDRLINE_FKEYS= to allow the localized F-key assignments shown on the header line, instead of the constant F-key info.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-01-14  Jeno Vago  <gse@ha5se.hu>
+
+  * src/clear_display.c src/globalvars.h src/main.c src/parse_logcfg.c
+  Implementing configuration statement HDRLINE_FKEYS= to allow the localized
+  F-key assignments shown on the header line, instead of the constant F-key info.
+
 2019-10-28  Thomas Beierlein <tomjbe@gentoo.org>
 
   * NEWS, ToDo: Update NEWS and ToDo files

--- a/src/clear_display.c
+++ b/src/clear_display.c
@@ -45,8 +45,6 @@
 
 
 void show_header_line() {
-    extern const char headerline[];
-
     char *mode = "";
     switch (cqmode) {
 	case CQ:

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -233,6 +233,9 @@ extern char *config_file;
 extern int bandindexarray[];
 extern int tlfcolors[8][2];
 
+// 2021-01-23 HA5SE implementing HDRLINE_FKEYS=
+extern char headerline[];
+
 extern SCREEN *mainscreen;
 
 extern bool mult_side;

--- a/src/main.c
+++ b/src/main.c
@@ -381,7 +381,7 @@ freq_t bandfrequency[NBANDS] = {
     28025000, 0.
 };
 
-const char headerline[] =
+char headerline[] =
     "   1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?  ";
 const char *backgrnd_str;
 

--- a/src/parse_logcfg.c
+++ b/src/parse_logcfg.c
@@ -1027,6 +1027,18 @@ static int cfg_cabrillo_field(const cfg_arg_t arg) {
     return rc;
 }
 
+// 2021-01-23 HA5SE implementing HDRLINE_FKEYS=
+static int cfg_headerline(const cfg_arg_t arg) {
+    char *str = g_ascii_strup(parameter, -1);
+    if (strlen(str) >= 58) {
+	g_free(str);
+	return PARSE_STRING_TOO_LONG;
+    }
+    strcpy(headerline+3, str);
+    g_free(str);
+    return PARSE_OK;
+}
+
 static config_t logcfg_configs[] = {
     {"CONTEST_MODE",        CFG_BOOL_TRUE(iscontest)},
     {"MIXED",               CFG_BOOL_TRUE(mixedmode)},
@@ -1188,6 +1200,8 @@ static config_t logcfg_configs[] = {
     {"UNIQUE_CALL_MULTI",   NEED_PARAM, cfg_unique_call_multi},
     {"DIGI_RIG_MODE",       NEED_PARAM, cfg_digi_rig_mode},
     {"CABRILLO-(.+)",       OPTIONAL_PARAM, cfg_cabrillo_field},
+
+    {"HDRLINE_FKEYS",   NEED_PARAM, cfg_headerline},
 
     {NULL}  // end marker
 };

--- a/tlf.1.in
+++ b/tlf.1.in
@@ -1595,6 +1595,13 @@ BK,
 = his serial (e.g. confirm exchange of station in DIGIMODE).
 .
 .TP
+\fBHDRLINE_FKEYS\fR=\fI"short description of your defined F-keys"\fR
+On the main logging screen, the actual F-key assignments can be shown in the header line.
+Maximum length is 58.
+The default is:
+   HDRLINE_FKEYS= 1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?
+.
+.TP
 \fBF1\fR=\fI"cw message 1"\fR
 CQ message, (e.g. CQ de PA0R TEST).
 .


### PR DESCRIPTION
Instead of the hard-coded screen header line

`     1=CQ  2=DE  3=RST 4=73  5=HIS  6=MY  7=B4   8=AGN  9=?`

rather allow to customize this line along with the customized F-key-definitions.